### PR TITLE
env must be an array, not object

### DIFF
--- a/akeyless-services/values.yaml
+++ b/akeyless-services/values.yaml
@@ -78,7 +78,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-env: {}
+env: []
   # Any environment variables needed
 
 HPA:


### PR DESCRIPTION
Error
===

Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.containers[0].env): invalid type for io.k8s.api.core.v1.Container.env: got "map", expected "array"

kubectl explain StatefulSet.spec.template.spec.containers.env
===
KIND:     StatefulSet
VERSION:  apps/v1

RESOURCE: env <[]Object>

DESCRIPTION:
     List of environment variables to set in the container. Cannot be updated.

     EnvVar represents an environment variable present in a Container.

FIELDS:
   name <string> -required-
     Name of the environment variable. Must be a C_IDENTIFIER.

   value        <string>
     Variable references $(VAR_NAME) are expanded using the previous defined
     environment variables in the container and any service environment
     variables. If a variable cannot be resolved, the reference in the input
     string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
     double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
     regardless of whether the variable exists or not. Defaults to "".

   valueFrom    <Object>
     Source for the environment variable's value. Cannot be used if value is not
     empty.