### PR TITLE
Update web-worker-deployment.yaml

### DIFF
--- a/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -22,9 +22,11 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
+        {{ if and .Values.persistence .Values.persistence.shareStorageVolume }}
         - name: {{ .Values.persistence.shareStorageVolume.name | title | lower }}
           persistentVolumeClaim:
             claimName: {{ printf "%s-%s" $.Release.Name .Values.persistence.shareStorageVolume.name | title | lower }}
+        {{ end }}
       containers:
         - name: {{ .Values.webWorker.containerName }}
           image: "{{ .Values.webWorker.image.repository }}:{{ .Values.webWorker.image.tag }}"
@@ -46,8 +48,10 @@ spec:
             mountPath: /dev/shm
           - name: configmap-policies
             mountPath: /usr/lib/firefox/distribution
+          {{ if and .Values.persistence .Values.persistence.shareStorageVolume }}
           - name: {{ .Values.persistence.shareStorageVolume.name | title | lower }}
             mountPath: /etc/shared
+          {{ end }}
           resources:
 {{- toYaml .Values.webWorker.resources | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
.Values.persistence.shareStorageVolume is optional

Error: template: akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml:25:26: executing "akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml" at <.Values.persistence.shareStorageVolume.name>: nil pointer evaluating interface {}.name
  on akeyless.tf line 29, in resource "helm_release" "akeyless_web_access":
  29: resource "helm_release" "akeyless_web_access" {